### PR TITLE
Fixing an issue which caused dropdownlists to flicker

### DIFF
--- a/dist/js/materialize.js
+++ b/dist/js/materialize.js
@@ -1771,7 +1771,7 @@ if (Vel) {
             hideDropdown();
             $(document).off('click.' + activates.attr('id'));
           });
-        }, 0);
+        }, 100);
       }
 
       function hideDropdown() {

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -190,7 +190,7 @@
             hideDropdown();
             $(document).off('click.'+ activates.attr('id'));
           });
-        }, 0);
+        }, 100);
       }
 
       function hideDropdown() {


### PR DESCRIPTION
Chrome recently released v93, which affected selects (drop down lists) and date pickers in multiple JavaScript framework and libraries.
This pull request should fix the select list not opening on first mouse click

Materialize issue: [Dogfalo/materialize/#6322](https://github.com/Dogfalo/materialize/issues/6322)
Chromium bug: [#941910](https://bugs.chromium.org/p/chromium/issues/detail?id=941910)